### PR TITLE
Handle snapshot requests for vmc 3030

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pyaml==20.4.0
 python-vlc==3.0.11115
 PyYAML==5.3.1
 requests==2.25.0
+requests_toolbelt.multipart==0.10.1
 standardjson==0.3.1
 urllib3==1.26.2
 webhooks==0.4.2


### PR DESCRIPTION
When snapshot from VMC 3030s are posted to the api, they do not exist in the `flask.request.files` object. Instead, they need to be loaded directly from the data stream using the multipart decoder.

I don't think this should break other cameras, but I do not have another type to test on. Should you find your camera does not work with these changes, I'll glady address the issues to ensure compatibillity with all cameras.