### PR TITLE
Use buildx to build and push multiarch docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,18 +9,33 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - 
+      -
         name: Docker Hub Login
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - 
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
         name: Checkout
         uses: actions/checkout@v3
-      - 
-        name: Build Docker Image
-        run: docker build . --file Dockerfile --tag bschrameck/arlo-cam-api:$(date +%s) --tag bschrameck/arlo-cam-api:latest
-      - 
-        name: Docker Push
-        run: docker push --all-tags bschrameck/arlo-cam-api
+      -
+        name: Get Date
+        id: date
+        run: echo "date=$(date +%s)" >> $GITHUB_OUTPUT
+      -
+        name: Build and push Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            bschrameck/arlo-cam-api:latest
+            bschrameck/arlo-cam-api:${{ steps.date.outputs.date }}


### PR DESCRIPTION
As per the title, this alters the workflow to push a single multi-arch capable docker image. This allows pulling on arm/v7 (RPi3) and arm64 (RPi4 and other SBCs).