### PR TITLE
Persist PIRStartState and  PIRStartSensitivity to DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,6 @@ A camera *on battery power* reports near ambient temperatures for it's temperatu
 
 5. The live stream can be pretty jittery. Make sure you have VERY strong Wi-Fi coverage for the cameras.
 
-6. You can't control the cameras without using the REST API directly. They are defaulted to always "armed" which means they will always send a motion notification. Video quality is defaulted to "subscription". Even if you DO control them, their state will be reset the next time they register with WiFi. Will have to build in storage of settings later.
+6. You can't control the cameras without using the REST API directly. They are defaulted to always "armed" which means they will always send a motion notification. Video quality is defaulted to "subscription" can can be set w/ the `VideoQualityDefault` parameter. The `PIRStartState` (`Armed` or `Disarmed`) and `PIRStartSensitivity` values are saved and will applied when the camera connects to the base station.  Other custom settings are not yet persistent.
 
 7. The camera streams have no authentication mechanism, and they are sent unencrypted over the wire. Use them only on a network you own and trust, as anybody could theoretically listen to the traffic and reconstruct the video by sniffing the packets.

--- a/arlo/audio_doorbell.py
+++ b/arlo/audio_doorbell.py
@@ -14,19 +14,22 @@ class AudioDoorbell(Device):
     def port(self):
         return 4100
 
-    def send_initial_register_set(self, wifi_country_code, video_anti_flicker_rate=None):
+    def send_initial_register_set(self, wifi_country_code, video_anti_flicker_rate=None, pir_start_state="Armed", pir_start_sensitivity=30):
         registerSet = Message(copy.deepcopy(arlo.messages.AUDIO_DOORBELL_INITIAL_REGISTER_SET))
         self.send_message(registerSet)
 
         registerSet = Message(copy.deepcopy(arlo.messages.AUDIO_DOORBELL_SECOND_REGISTER_SET))
         registerSet['SetValues']['WifiCountryCode'] = wifi_country_code
         self.send_message(registerSet)
+        self.set_pir_settings(pir_start_state, pir_start_sensitivity, 30)
 
     def arm(self, args):
         register_set = Message(copy.deepcopy(arlo.messages.REGISTER_SET))
 
         pir_target_state = args['PIRTargetState']
         pir_start_sensitivity = args.get('PIRStartSensitivity') or 30
+
+        self.validate_arm_args(pir_target_state, pir_start_sensitivity)
 
         register_set["SetValues"] = {
             "PIRTargetState": pir_target_state,

--- a/arlo/camera.py
+++ b/arlo/camera.py
@@ -17,7 +17,7 @@ class Camera(Device):
     def port(self):
         return 4000
 
-    def send_initial_register_set(self, wifi_country_code, video_anti_flicker_rate=None, video_quality_default='default'):
+    def send_initial_register_set(self, wifi_country_code, video_anti_flicker_rate=None, video_quality_default='default', pir_start_state="Armed", pir_start_sensitivity=80):
         if self.model_number.startswith('VMC5040'):
             registerSet = Message(copy.deepcopy(arlo.messages.REGISTER_SET_INITIAL_ULTRA))
         elif self.model_number.startswith('FB1001'):
@@ -33,6 +33,7 @@ class Camera(Device):
             video_quality_default = 'insane'
 
         self.set_quality({'quality': video_quality_default})
+        self.set_pir_settings(pir_start_state, pir_start_sensitivity, 80)
 
     def pir_led(self, args):
         register_set = Message(copy.deepcopy(arlo.messages.REGISTER_SET))
@@ -105,6 +106,8 @@ class Camera(Device):
         pir_action = args.get('PIRAction') or 'Stream'
         video_motion_estimation_enable = args.get('VideoMotionEstimationEnable') or False
         audio_target_state = args.get('AudioTargetState') or 'Disarmed'
+
+        self.validate_arm_args(pir_target_state, pir_start_sensitivity)
 
         register_set["SetValues"] = {
             "PIRTargetState": pir_target_state,

--- a/arlo/video_doorbell.py
+++ b/arlo/video_doorbell.py
@@ -14,7 +14,7 @@ class VideoDoorbell(Camera):
     def port(self):
         return 4000
 
-    def send_initial_register_set(self, wifi_country_code, video_anti_flicker_rate=None, video_quality_default='default'):
+    def send_initial_register_set(self, wifi_country_code, video_anti_flicker_rate=None, video_quality_default='default', pir_start_state="Armed", pir_start_sensitivity=80):
         registerSet = Message(copy.deepcopy(arlo.messages.REGISTER_SET_INITIAL_VID_DOORBELL))
         self.send_message(registerSet, 4100)
 
@@ -27,6 +27,7 @@ class VideoDoorbell(Camera):
             video_quality_default = '1536sq'
 
         self.set_quality({'quality': video_quality_default})
+        self.set_pir_settings(pir_start_state, pir_start_sensitivity, 80)
 
     def set_quality(self, args):
         quality = args['quality'].lower()
@@ -49,6 +50,8 @@ class VideoDoorbell(Camera):
 
         pir_target_state = args['PIRTargetState']
         pir_start_sensitivity = args.get('PIRStartSensitivity') or 80
+
+        self.validate_arm_args(pir_target_state, pir_start_sensitivity)
 
         register_set['SetValues'] = {
             'PIRTargetState': pir_target_state,

--- a/server.py
+++ b/server.py
@@ -29,7 +29,7 @@ with sqlite3.connect('arlo.db') as conn:
         c.execute('DROP INDEX IF EXISTS idx_device_hostname')
         c.execute('ALTER TABLE camera RENAME TO devices')
 
-    c.execute("CREATE TABLE IF NOT EXISTS devices (ip text, serialnumber text, hostname text, status text, register_set text, friendlyname text)")
+    c.execute("CREATE TABLE IF NOT EXISTS devices (ip text, serialnumber text, hostname text, status text, register_set text, friendlyname text, pir_status text, pir_start_sensitivity integer, last_update integer)")
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_device_serialnumber ON devices (serialnumber)")
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_device_ip ON devices (ip)")
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_device_friendlyname ON devices (friendlyname)")
@@ -72,7 +72,7 @@ class ConnectionThread(threading.Thread):
                     DeviceDB.persist(device)
                     s_print(f"<[{self.ip}][{msg['ID']}] Registration from {msg['SystemSerialNumber']} - {device.hostname}")
 
-                    device.send_initial_register_set(WIFI_COUNTRY_CODE, VIDEO_ANTI_FLICKER_RATE, VIDEO_QUALITY_DEFAULT)
+                    device.send_initial_register_set(WIFI_COUNTRY_CODE, VIDEO_ANTI_FLICKER_RATE, VIDEO_QUALITY_DEFAULT, pir_start_state=device.pir_start_state, pir_start_sensitivity=device.pir_start_sensitivity)
                     webhook_manager.registration_received(
                         device.ip, device.friendly_name, device.hostname, device.serial_number, device.registration)
                 elif (msg['Type'] == "status"):


### PR DESCRIPTION
- persist `PIRStartState` and `PIRStartSensitivity` to database
- Log timestamp when `DeviceDB.persist` is called