### PR TITLE
Ability to disable alll webhooks and minor improvements to logging and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 COPY requirements.txt /tmp
 RUN pip3 install -r /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ If you are using this server with Scrypted:
 1. (Optional) Create a file to store the sqlite database used by the server and mount it.
 
 ```
-version: '3.8'
 services:
   arlo-cam-api:
     container_name: 'arlo-cam-api'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ First, create a `config.yaml` file (available in this repo) that will be used to
 WifiCountryCode: "US"
 VideoAntiFlickerRate: 60
 VideoQualityDefault: "default"
+NotifyRegisteredAndStatusUpdate: true
 NotifyOnMotionAlert: true
 NotifyOnMotionTimeoutAlert: false
 NotifyOnAudioAlert: false
@@ -46,12 +47,14 @@ ButtonPressWebHookUrl: "http://192.168.1.100:4321/endpoint/@scrypted/arlo-local/
 
 You'll want to replace the `WifiCountryCode` with your two-letter ISO3166-1 alpha-2 code, and the `VideoAntiFlickerRate` with `50` or `60`—whatever electrical frequency your country uses (e.g. most of Europe uses 50 Hz, the US uses 60 Hz).
 
-. If you want to use webhooks, currently only the following webhooks are functional:
+If you want to use webhooks, currently only the following webhooks are functional:
 - `RegistrationWebHookUrl`
 - `StatusUpdateWebHookUrl`
 - `MotionRecordingWebHookUrl`
 - `MotionTimeoutWebHookUrl`
 - `ButtonPressWebHookUrl`
+
+You can disable all webhooks by setting all `Notify*` settings to `false`.
 
 If you are using this server with Scrypted:
 - Replace `RegistrationWebHookUrl` with the `Registration Webhook` from the Scrypted plugin configuration.
@@ -266,6 +269,67 @@ paths:
     maxReaders: 1
 ```
 You can use FFmpeg save the video by streaming from mediamtx.  You can also live stream by connecting mediamtx's webrtc/hls port on a browser.
+
+### Using video stream in Frigate
+
+The MediaMTX method offers the most reliable approach for stream handling. Besides the standard stream configuration, MediaMTX provides the flexibility to define a low-resolution stream specifically for object detection. This is particularly useful for minimizing resource consumption and detection costs when Frigate and MediaMTX are on different machines. Configure your desired stream(s) in your `mediamtx.yml` file:
+
+```yaml
+paths:
+  arlo_cam_lo:
+    arlo_cam:
+      source: rtsp://IP/live
+      rtspAnyPort: yes
+      runOnReady: >
+        ffmpeg -i rtsp://localhost:$RTSP_PORT/$MTX_PATH
+          -c:v libx264  -preset ultrafast -crf 0 
+          -an -vf scale=640:360
+          -f rtsp rtsp://localhost:$RTSP_PORT/arlo_cam_lo
+      runOnReadyRestart: yes
+```
+
+Next, set up the stream in Frigate by adding the following to its `config.yml`:
+
+```yaml
+go2rtc:
+  streams:
+    arlo_cam:
+      - rtsp://mediamtx:8554/arlo_cam
+      # For audio enable the following
+        - ffmpeg:arlo_cam#audio=opus
+    # Low res stream from MediaMTX
+    arlo_cam_lo:
+      - rtsp://mediamtx:8554/arlo_cam_lo
+
+cameras:
+  arlo_cam:
+    enabled: true
+    # Enable for audio
+    ffmpeg:
+      output_args:
+        record: preset-record-generic-audio-copy
+      inputs:
+        - path: rtsp://127.0.0.1:8554/arlo_cam
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+            - audio
+        - path: rtsp://127.0.0.1:8554/arlo_cam_lo
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+    record:
+      enabled: true
+    audio:
+      enabled: true
+    detect:
+      enabled: true
+      width: 640
+      height: 360
+    live:
+      stream_name: arlo_cam
+```
+
 ## Audio Streaming to the Camera
 
 The UDP port 5000 on the cameras constantly listens for RTP traffic with the following encoding:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 WifiCountryCode: "US"
 VideoAntiFlickerRate: 60
 VideoQualityDefault: "default"
+NotifyRegisteredAndStatusUpdate: true
 NotifyOnMotionAlert: true
 NotifyOnMotionTimeoutAlert: false
 NotifyOnAudioAlert: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ standardjson==0.3.1
 urllib3==1.26.2
 webhooks==0.4.2
 Werkzeug==1.0.1
-wrapt==1.12.1
+wrapt==1.17.1

--- a/server.py
+++ b/server.py
@@ -110,6 +110,8 @@ class ConnectionThread(threading.Thread):
                     else:
                         s_print(f"<[{self.ip}][{msg['ID']}] Unknown alert type")
                         s_print(msg)
+                elif (msg['Type'] == "logMessage"):
+                    s_print(f"<[{self.ip}][{msg['ID']}] {msg['AlertType']} {msg['LogString']}")
                 else:
                     s_print(f"<[{self.ip}][{msg['ID']}] Unknown message")
                     s_print(msg)

--- a/server.py
+++ b/server.py
@@ -114,7 +114,7 @@ class ConnectionThread(threading.Thread):
                         s_print(f"<[{self.ip}][{msg['ID']}] Unknown alert type")
                         s_print(msg)
                 elif (msg['Type'] == "logMessage"):
-                    s_print(f"<[{self.ip}][{msg['ID']}] {msg['AlertType']} {msg['LogString']}")
+                    s_print(f"<[{self.ip}][{msg['ID']}] {msg['LogString']}")
                 else:
                     s_print(f"<[{self.ip}][{msg['ID']}] Unknown message")
                     s_print(msg)

--- a/server.py
+++ b/server.py
@@ -44,6 +44,7 @@ NOTIFY_ON_MOTION_ALERT = config.get('NotifyOnMotionAlert', True)
 NOTIFY_ON_MOTION_TIMEOUT_ALERT = config.get('NotifyOnMotionTimeoutAlert', False)
 NOTIFY_ON_AUDIO_ALERT = config.get('NotifyOnAudioAlert', False)
 NOTIFY_ON_BUTTON_PRESS_ALERT = config.get('NotifyOnButtonPressAlert', True)
+NOTIFY_REGISTERD_AND_STATUS_UPDATE = config.get('NotifyRegisteredAndStatusUpdate', True)
 
 
 class ConnectionThread(threading.Thread):
@@ -73,16 +74,18 @@ class ConnectionThread(threading.Thread):
                     s_print(f"<[{self.ip}][{msg['ID']}] Registration from {msg['SystemSerialNumber']} - {device.hostname}")
 
                     device.send_initial_register_set(WIFI_COUNTRY_CODE, VIDEO_ANTI_FLICKER_RATE, VIDEO_QUALITY_DEFAULT)
-                    webhook_manager.registration_received(
-                        device.ip, device.friendly_name, device.hostname, device.serial_number, device.registration)
+                    if NOTIFY_REGISTERD_AND_STATUS_UPDATE:
+                        webhook_manager.registration_received(
+                            device.ip, device.friendly_name, device.hostname, device.serial_number, device.registration)
                 elif (msg['Type'] == "status"):
                     s_print(f"<[{self.ip}][{msg['ID']}] Status from {msg['SystemSerialNumber']}")
                     device = DeviceDB.from_db_serial(msg['SystemSerialNumber'])
                     device.ip = self.ip
                     device.status = msg
                     DeviceDB.persist(device)
-                    webhook_manager.status_received(device.ip, device.friendly_name,
-                                                    device.hostname, device.serial_number, device.status)
+                    if NOTIFY_REGISTERD_AND_STATUS_UPDATE:
+                        webhook_manager.status_received(device.ip, device.friendly_name,
+                                                        device.hostname, device.serial_number, device.status)
                     device.send_epoch_bs_time()
                 elif (msg['Type'] == "alert"):
                     device = DeviceDB.from_db_ip(self.ip)

--- a/server.py
+++ b/server.py
@@ -88,21 +88,25 @@ class ConnectionThread(threading.Thread):
                     device = DeviceDB.from_db_ip(self.ip)
                     alert_type = msg['AlertType']
                     s_print(f"<[{self.ip}][{msg['ID']}] {msg['AlertType']}")
-                    if alert_type == "pirMotionAlert" and NOTIFY_ON_MOTION_ALERT:
-                        webhook_manager.motion_detected(
-                            device.ip, device.friendly_name, device.hostname, device.serial_number,
-                            msg['PIRMotion'].get('zones', []),
-                            "")
-                    elif alert_type == "audioAlert" and NOTIFY_ON_AUDIO_ALERT:
-                        # TODO: implement this
-                        ...
-                    elif alert_type == "buttonPressAlert" and NOTIFY_ON_BUTTON_PRESS_ALERT:
-                        webhook_manager.button_pressed(
-                            device.ip, device.friendly_name, device.hostname, device.serial_number,
-                            msg['ButtonPress']['Triggered'])
-                    elif alert_type == "motionTimeoutAlert" and NOTIFY_ON_MOTION_TIMEOUT_ALERT:
-                        webhook_manager.motion_timeout(
-                            device.ip, device.friendly_name, device.hostname, device.serial_number)
+                    if alert_type == "pirMotionAlert" :
+                        if NOTIFY_ON_MOTION_ALERT:
+                            webhook_manager.motion_detected(
+                                device.ip, device.friendly_name, device.hostname, device.serial_number,
+                                msg['PIRMotion'].get('zones', []),
+                                "")
+                    elif alert_type == "audioAlert":
+                        if NOTIFY_ON_AUDIO_ALERT:
+                            # TODO: implement this
+                            ...
+                    elif alert_type == "buttonPressAlert":
+                        if NOTIFY_ON_BUTTON_PRESS_ALERT:
+                            webhook_manager.button_pressed(
+                                device.ip, device.friendly_name, device.hostname, device.serial_number,
+                                msg['ButtonPress']['Triggered'])
+                    elif alert_type == "motionTimeoutAlert":
+                        if NOTIFY_ON_MOTION_TIMEOUT_ALERT:
+                            webhook_manager.motion_timeout(
+                                device.ip, device.friendly_name, device.hostname, device.serial_number)
                     else:
                         s_print(f"<[{self.ip}][{msg['ID']}] Unknown alert type")
                         s_print(msg)


### PR DESCRIPTION
This pull request introduces the ability to disable all webhook functionality within the application. This is particularly useful during initial setup or in scenarios where webhook integrations are not required, such as my initial integration with Frigate and Home Assistant.

Additionally, this PR includes minor logging enhancements:

- Adds support for the ```logMessages``` type.
- Resolves an issue where supported log types were incorrectly flagged as unsupported when webhooks were disabled.
- Finally, basic documentation regarding Frigate integration has been added.

Last but not least, the Python version was bumped to 3.11, as I had some issues with the wrapt library.