### PR TITLE
Fix send_file for Flask 3: attachment_filename -> download_name

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -206,7 +206,7 @@ def get_snapshot(identifier):
         # delete the file
         os.remove(target_path)
         # send it to client
-        return send_file(return_data, mimetype='image/jpeg', attachment_filename=f'{identifier}.jpg')
+        return send_file(return_data, mimetype='image/jpeg', download_name=f'{identifier}.jpg')
 
 
 @app.route('/device/<serial>/message', methods=['POST'])


### PR DESCRIPTION
`requirements.txt` pins `Flask==3.1.3`, but `send_file()`'s `attachment_filename` keyword was removed in Flask 2.2 (renamed to `download_name`).

On a clean install of the pinned requirements, every snapshot retrieval fails:

```
GET /snapshot/<identifier> HTTP/1.1" 500 -
TypeError: send_file() got an unexpected keyword argument 'attachment_filename'
```

This hit me upgrading a deployment that had been running Flask 1.1.2 — the API came up fine and only snapshot GETs failed. Scrypted's polling turned it into a steady stream of 500s.

One-word change. Verified after the fix: `GET /snapshot/<serial>` returns 200 with a valid JPEG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)